### PR TITLE
log latency with fixed time unit

### DIFF
--- a/logr.go
+++ b/logr.go
@@ -65,6 +65,7 @@ func Ginlogr(logger logr.Logger, timeFormat string, utc, addToReqContext bool, w
 			"user-agent", c.Request.UserAgent(),
 			"time", end.Format(timeFormat),
 			"latency", latency,
+			"logger", "ginlogr",
 		)
 	}
 }

--- a/logr.go
+++ b/logr.go
@@ -45,7 +45,7 @@ func Ginlogr(logger logr.Logger, timeFormat string, utc, addToReqContext bool, w
 		c.Next()
 
 		end := time.Now()
-		latency := end.Sub(start)
+		latency := end.Sub(start).Microseconds()
 		if utc {
 			end = end.UTC()
 		}


### PR DESCRIPTION
Latency gets logged as a `time.Duration` string which means it could be `"312ms"` or `"45ns"` or `"102µs"`. This changes the latency to always be an `int64` value in microseconds. This allows DataDog and similar tools to use this value more meaningfully.

This also adds a `"logger"` attribute with value `"ginlogr"`. This will allow DataDog and similar tools to parse out logs that are coming from GinLogr with a known format. 